### PR TITLE
fix: Add `id` to README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Each token in the list contains the following information:
 
 ```json
 {
+  "id": "TKN-mainnet",
   "name": "Token Name",
   "address": "0x...",
   "symbol": "TKN",


### PR DESCRIPTION
# Changes

* Add `id` to the README example

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a unique identifier for tokens to enhance tracking and management within the ecosystem.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->