### PR TITLE
chore: upgrade GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,15 +10,15 @@ jobs:
     permissions:
       contents: write  # Required to push historical snapshot to main
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: main  # Checkout main branch, not the release tag
           fetch-depth: 0  # Fetch all history to access previous versions
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
-          node-version: "18"
+          node-version: "22"
           cache: "npm"
 
       - name: Install dependencies
@@ -142,7 +142,7 @@ jobs:
           fi
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,12 +8,12 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
-          node-version: "18"
+          node-version: "22"
           cache: "npm"
 
       - name: Install dependencies


### PR DESCRIPTION
## Problem
Deploy and PR validation workflows use GitHub Actions running on deprecated Node.js 20. These will be forced to Node.js 24 starting June 2, 2026.

## Proposed Solution
- `actions/checkout@v3`/`@v5` → `@v6`
- `actions/setup-node@v3` → `@v6`
- `peaceiris/actions-gh-pages@v3` → `@v4` (latest)
- `node-version` 18 → 22

## Considerations
- Both `deploy.yml` and `pr.yml` updated
- All actions bumped to latest available major versions

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)