### PR TITLE
fix: denominate tron currencies as erc20

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -26,6 +26,7 @@ export enum TokenType {
   ISO4217 = "ISO4217",
   ERC20 = "ERC20",
   ETH = "ETH",
+  // TODO change the token lists for Tron to use TRC20 after we fix https://github.com/RequestNetwork/requestNetwork/issues/1713
   TRC20 = "TRC20",
 }
 

--- a/tokens/token-list.json
+++ b/tokens/token-list.json
@@ -8176,7 +8176,7 @@
       "decimals": 6,
       "address": "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
       "network": "tron",
-      "type": "ERC20", 
+      "type": "ERC20",
       "hash": "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
       "chainId": 728126428
     },

--- a/tokens/token-list.json
+++ b/tokens/token-list.json
@@ -8176,7 +8176,7 @@
       "decimals": 6,
       "address": "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
       "network": "tron",
-      "type": "TRC20",
+      "type": "ERC20", 
       "hash": "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
       "chainId": 728126428
     },
@@ -8187,7 +8187,7 @@
       "decimals": 6,
       "address": "TEkxiTehnzSmSe2XqrBj4w32RUN966rdz8",
       "network": "tron",
-      "type": "TRC20",
+      "type": "ERC20",
       "hash": "TEkxiTehnzSmSe2XqrBj4w32RUN966rdz8",
       "chainId": 728126428
     }

--- a/tokens/token-list.json
+++ b/tokens/token-list.json
@@ -4,7 +4,7 @@
   "version": {
     "major": 1,
     "minor": 5,
-    "patch": 0
+    "patch": 1
   },
   "tokens": [
     {

--- a/versions/v1.5.0.json
+++ b/versions/v1.5.0.json
@@ -8176,7 +8176,7 @@
       "decimals": 6,
       "address": "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
       "network": "tron",
-      "type": "ERC20",
+      "type": "TRC20",
       "hash": "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
       "chainId": 728126428
     },
@@ -8187,7 +8187,7 @@
       "decimals": 6,
       "address": "TEkxiTehnzSmSe2XqrBj4w32RUN966rdz8",
       "network": "tron",
-      "type": "ERC20",
+      "type": "TRC20",
       "hash": "TEkxiTehnzSmSe2XqrBj4w32RUN966rdz8",
       "chainId": 728126428
     }

--- a/versions/v1.5.0.json
+++ b/versions/v1.5.0.json
@@ -8176,7 +8176,7 @@
       "decimals": 6,
       "address": "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
       "network": "tron",
-      "type": "TRC20",
+      "type": "ERC20",
       "hash": "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
       "chainId": 728126428
     },
@@ -8187,7 +8187,7 @@
       "decimals": 6,
       "address": "TEkxiTehnzSmSe2XqrBj4w32RUN966rdz8",
       "network": "tron",
-      "type": "TRC20",
+      "type": "ERC20",
       "hash": "TEkxiTehnzSmSe2XqrBj4w32RUN966rdz8",
       "chainId": 728126428
     }


### PR DESCRIPTION
### TL;DR

Temporarily changed Tron token types from TRC20 to ERC20 as a workaround for issue #1713

### What changed?

- Added a TODO comment in the TokenType enum indicating this is a temporary change
- Changed the token type for two Tron tokens (USDT and USDC) from "TRC20" to "ERC20" in both the main token list and v1.5.0 version file

### How to test?

- Verify that Tron tokens now have type "ERC20" instead of "TRC20" in the token lists
- Test that the application properly handles these Tron tokens with the ERC20 type designation
- Confirm that the TODO comment is present in the TokenType enum

### Why make this change?

This is a temporary workaround to address issue #1713 in the RequestNetwork repository. The change allows Tron tokens to function properly until the underlying issue with TRC20 token handling is resolved.