### PR TITLE
feat(tokens): add EURC on Ethereum and Base

### DIFF
--- a/tokens/token-list.json
+++ b/tokens/token-list.json
@@ -3,7 +3,7 @@
   "timestamp": "Set automatically during deployment",
   "version": {
     "major": 1,
-    "minor": 5,
+    "minor": 6,
     "patch": 0
   },
   "tokens": [
@@ -5662,6 +5662,17 @@
       "chainId": 1
     },
     {
+      "id": "EURC-mainnet",
+      "name": "EUR Coin",
+      "symbol": "EURC",
+      "decimals": 6,
+      "address": "0x1aBaEA1f7C830bD89Acc67eC4af516284b1bC33c",
+      "network": "mainnet",
+      "type": "ERC20",
+      "hash": "0x1aBaEA1f7C830bD89Acc67eC4af516284b1bC33c",
+      "chainId": 1
+    },
+    {
       "id": "PNK-mainnet",
       "name": "PNK",
       "symbol": "PNK",
@@ -8134,6 +8145,17 @@
       "network": "base",
       "type": "ERC20",
       "hash": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      "chainId": 8453
+    },
+    {
+      "id": "EURC-base",
+      "name": "EUR Coin",
+      "symbol": "EURC",
+      "decimals": 6,
+      "address": "0x60a3E35Cc302bFA44Cb288Bc5a4F316Fdb1adb42",
+      "network": "base",
+      "type": "ERC20",
+      "hash": "0x60a3E35Cc302bFA44Cb288Bc5a4F316Fdb1adb42",
       "chainId": 8453
     },
     {


### PR DESCRIPTION
### TL;DR

Added EURC (EUR Coin) token support on Ethereum mainnet and Base networks.

### What changed?

EURC (EUR Coin) has been added to the token list for two networks:

- **Mainnet** at address `0x1aBaEA1f7C830bD89Acc67eC4af516284b1bC33c`
- **Base** at address `0x60a3E35Cc302bFA44Cb288Bc5a4F316Fdb1adb42`

Both entries are ERC20 tokens with 6 decimals. The token list version has been bumped from `1.5.0` to `1.6.0`.

### How to test?

Verify that EURC appears and resolves correctly on both Ethereum mainnet and Base by searching for the token symbol or address in any interface that consumes this token list.

### Why make this change?

EURC is Circle's Euro-backed stablecoin. Adding it to the token list enables users to transact with a Euro-denominated stablecoin across Ethereum mainnet and Base.