### PR TITLE
feat(tokens): add USDT0 on Optimism

### DIFF
--- a/tokens/token-list.json
+++ b/tokens/token-list.json
@@ -3,7 +3,7 @@
   "timestamp": "Set automatically during deployment",
   "version": {
     "major": 1,
-    "minor": 6,
+    "minor": 7,
     "patch": 0
   },
   "tokens": [
@@ -7815,6 +7815,17 @@
       "network": "optimism",
       "type": "ERC20",
       "hash": "0x94b008aA00579c1307B0EF2c499aD98a8ce58e58",
+      "chainId": 10
+    },
+    {
+      "id": "USDT0-optimism",
+      "name": "USDT0",
+      "symbol": "USDT0",
+      "decimals": 6,
+      "address": "0x01bFF41798a0BcF287b996046Ca68b395DbC1071",
+      "network": "optimism",
+      "type": "ERC20",
+      "hash": "0x01bFF41798a0BcF287b996046Ca68b395DbC1071",
       "chainId": 10
     },
     {


### PR DESCRIPTION
# Problem

Cross-chain payments funded with **USDT0 on Optimism** fail on the secure payment page. After the LiFi quote succeeds, request-api's `getTokenList()` lookup 404s with `"Invoice currency not found"` because **USDT0 is not in this token list** — only legacy `USDT-optimism` (`0x94b008aA…`) is registered. USDT0 (`0x01bFF41798a0BcF287b996046Ca68b395DbC1071`) is now the canonical Optimism USDT, and REQ-190 added it to request-api's routing map, but the currency registry (this list) was never updated.

Refs REQ-190. Pairs with RequestNetwork/request-api#1065 (which surfaces + resolves USDT0 as a cross-chain source).

# Proposed Solution

Add `USDT0-optimism` to `tokens/token-list.json` (mirroring the existing `USDT-optimism` entry) and bump the list minor version 1.6.0 → 1.7.0.

```json
{
  "id": "USDT0-optimism",
  "name": "USDT0",
  "symbol": "USDT0",
  "decimals": 6,
  "address": "0x01bFF41798a0BcF287b996046Ca68b395DbC1071",
  "network": "optimism",
  "type": "ERC20",
  "hash": "0x01bFF41798a0BcF287b996046Ca68b395DbC1071",
  "chainId": 10
}
```

`npm run validate` → "Token list is valid!" and `npx vitest run` → 11/11 pass.

# Considerations

- Optimism is the only chain where USDT and USDT0 are distinct contracts; both stay listed. The `id` is `USDT0-optimism` to match what request-api's `resolveSourceCurrencyId` produces.
- Once merged and published (`deploy.yml` regenerates `latest.json`), request-api picks it up after its token-list cache expires — so it's not instant on staging/prod.
- No logo added (entries carry no logo field and the payment page renders the USDT0 icon from its own assets); happy to add one to `tokens/assets/` if preferred.

# UAT

On staging, open a USDC-on-Base request and pay cross-chain from a wallet holding only USDT0 on Optimism → selecting USDT0 now returns a quote and proceeds (previously 404'd after the quote).
